### PR TITLE
Output the ID of the newly created release for subsequent automation

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -118,6 +118,12 @@ workflows:
                 exit 1
               fi
 
+              if [ -z $APPCENTER_DEPLOY_RELEASE_ID ];
+              then
+                echo "ERROR: APPCENTER_DEPLOY_RELEASE_ID variable empty"
+                exit 1
+              fi
+
               if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
               then
                 echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
@@ -126,4 +132,5 @@ workflows:
 
               envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
               envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
+              envman add --key "APPCENTER_DEPLOY_RELEASE_ID" --value ""
               envman add --key "APPCENTER_DEPLOY_STATUS" --value ""

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"strconv"
 
 	"github.com/bitrise-io/appcenter"
 	"github.com/bitrise-io/go-steputils/stepconf"
@@ -156,6 +157,7 @@ func main() {
 		"APPCENTER_DEPLOY_INSTALL_URL":  release.InstallURL,
 		"APPCENTER_DEPLOY_DOWNLOAD_URL": release.DownloadURL,
 		"APPCENTER_RELEASE_PAGE_URL": fmt.Sprintf("https://appcenter.ms/orgs/%s/apps/%s/distribute/releases/%d", cfg.OwnerName, cfg.AppName, release.ID),
+		"APPCENTER_DEPLOY_RELEASE_ID": strconv.Itoa(release.ID),
 	}
 
 	if len(publicGroup) > 0 {

--- a/step.yml
+++ b/step.yml
@@ -139,6 +139,11 @@ outputs:
       title: Download URL
       summary: Download URL of the newly deployed version
       description: Download URL of the newly deployed version.
+  - APPCENTER_DEPLOY_RELEASE_ID:
+    opts:
+      title: Release ID
+      summary: ID of the new release for later retrieval via App Center APIs.
+      description: ID of the new release for later retrieval via App Center APIs.
   - APPCENTER_PUBLIC_INSTALL_PAGE_URL:
     opts:
       title: Public install page URL


### PR DESCRIPTION
Outputting the ID of the newly created App Center release, so it can be used in subsequent steps to retrieve the full release data, and manipulate the release further via App Center APIs

Currently only HTTP links are returned for manual interaction with the new release, thats all fine for logging and notification etc, but is not robust for further automation of the release (ie subsequent build steps that automate promotion and distribution of the new release through multiple App Center distribution groups via API).

By adding the release ID to the output it enables many use cases for subsequent automation

Tested by successful integration into our Bitrise CI pipeline