### PR TITLE
Remove distribution group requirement

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -79,7 +79,6 @@ inputs:
         User groups you wish to distribute the app. One group name per line.
 
         Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
-      is_required: true
   - distribution_store:
     opts:
       title: Distribution stores


### PR DESCRIPTION
Distribution group is not required in reality by AppCenter. 
It probably also does not make sense for AAB which is not directly installable.

### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR / MINOR / PATCH_ [version update](https://semver.org/)

### Context
Distribution group is not required in reality by AppCenter. 
It probably also does not make sense for AAB which is not directly installable.
<!--- One sentence summary on why the change is needed. -->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

Remove `is_required` flag from `distribution_group` field.

### Investigation details

We have workflows with steps distributing AAB to store without any group. After the step version update it started being required falsely.

<!-- Please share any alternative solutions that were considered along with investigation deatils. -->
