### PR TITLE
Fix AppCenter Distribute auto-updates after uploading a new release from Bitrise

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bitrise-steplib/steps-appcenter-deploy-android
 go 1.15
 
 require (
-	github.com/bitrise-io/appcenter v0.0.0-20210113093844-897d618265b0
+	github.com/bitrise-io/appcenter v0.0.0-20211207113933-9ff0a4c30357
 	github.com/bitrise-io/go-steputils v0.0.0-20201016102104-03ae3a6ded35
 	github.com/bitrise-io/go-utils v0.0.0-20201211082830-859032e9adf0
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bitrise-io/appcenter v0.0.0-20210113093844-897d618265b0 h1:e6jb9K5Oc73MxyNaiKWqZQ/gjew1O4xeA4pIXwxBWJo=
 github.com/bitrise-io/appcenter v0.0.0-20210113093844-897d618265b0/go.mod h1:sckBNZFMsD2KgfOtVlAFj3mGp8QlrqMsJYxNiuxSG3s=
+github.com/bitrise-io/appcenter v0.0.0-20211207113933-9ff0a4c30357 h1:hHXWhDnyLR/AAWYmPvJ2jARJVFrXdeySYAV9moVXisE=
+github.com/bitrise-io/appcenter v0.0.0-20211207113933-9ff0a4c30357/go.mod h1:sckBNZFMsD2KgfOtVlAFj3mGp8QlrqMsJYxNiuxSG3s=
 github.com/bitrise-io/go-steputils v0.0.0-20201016102104-03ae3a6ded35 h1:iKtx/RxSrA9xcjZ17W3yu3jMzwowNB6nxLF/1BwVYQ8=
 github.com/bitrise-io/go-steputils v0.0.0-20201016102104-03ae3a6ded35/go.mod h1:GXgBV3Frd3qcnsg+NryQTyx1CHjZHr/2w7Bx4WAcB4o=
 github.com/bitrise-io/go-utils v0.0.0-20201211082830-859032e9adf0 h1:HR5o2gHKo0rAMfKogclAg4KOnEX8XniC7A3JFuEAXjY=

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 	app := model.App{
 		Owner:   cfg.OwnerName,
 		AppName: cfg.AppName,
+		AppType: model.AppTypeAndroid,
 	}
 
 	releaseOptions := model.ReleaseOptions{

--- a/vendor/github.com/bitrise-io/appcenter/client/api.go
+++ b/vendor/github.com/bitrise-io/appcenter/client/api.go
@@ -332,12 +332,13 @@ func (api API) CreateRelease(opts model.ReleaseOptions) (int, error) {
 	fmt.Println(fmt.Sprintf("- File size: %s", strconv.Itoa(fileSize)))
 
 	var (
-		metadataURL = fmt.Sprintf("%s/upload/set_metadata/%s?file_name=%s&file_size=%s&token=%s",
+		metadataURL = fmt.Sprintf("%s/upload/set_metadata/%s?file_name=%s&file_size=%s&token=%s&content_type=%s",
 			assetResponse.UploadDomain,
 			assetResponse.PackageAssetID,
 			url.QueryEscape(fileName),
 			strconv.Itoa(fileSize),
-			assetResponse.URLEncodedToken)
+			assetResponse.URLEncodedToken,
+			getContentType(opts.App.AppType))
 		metadataResponse struct {
 			ID             string `json:"id"`
 			ChunkSize      int    `json:"chunk_size"`
@@ -482,6 +483,17 @@ func (api API) CreateRelease(opts model.ReleaseOptions) (int, error) {
 	fmt.Println(fmt.Sprintf("Release created with ID: %d", releaseDistinctID))
 
 	return releaseDistinctID, nil
+}
+
+func getContentType(appType model.AppType) (string) {
+	switch appType {
+	case model.AppTypeAndroid:
+		return "application/vnd.android.package-archive"
+	case model.AppTypeiOS:
+		return "application/octet-stream"
+	default:
+		return ""
+	}
 }
 
 func (api API) uploadChunksParallelly(fileChunks [][]byte, chunkIDs []int, assetResponse fileAssetResponse) (retErr error) {

--- a/vendor/github.com/bitrise-io/appcenter/model/app.go
+++ b/vendor/github.com/bitrise-io/appcenter/model/app.go
@@ -4,4 +4,5 @@ package model
 type App struct {
 	Owner   string
 	AppName string
+	AppType AppType
 }

--- a/vendor/github.com/bitrise-io/appcenter/model/app_type.go
+++ b/vendor/github.com/bitrise-io/appcenter/model/app_type.go
@@ -1,0 +1,10 @@
+package model
+
+// AppType ...
+type AppType int
+
+// AppTypeAndroid ...
+const (
+	AppTypeAndroid AppType = 1
+	AppTypeiOS     AppType = 2
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bitrise-io/appcenter v0.0.0-20210113093844-897d618265b0
+# github.com/bitrise-io/appcenter v0.0.0-20211207113933-9ff0a4c30357
 ## explicit
 github.com/bitrise-io/appcenter
 github.com/bitrise-io/appcenter/client


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context
Fixes AppCenter Distribute auto-updates after uploading a new release from Bitrise.

See: https://github.com/bitrise-steplib/steps-appcenter-deploy-android/issues/19

### Changes

  - Update shared AppCenter library.
  - Specify app type in release options

### Investigation details

See: https://github.com/bitrise-steplib/steps-appcenter-deploy-android/issues/19

### Decisions

See: https://github.com/bitrise-steplib/steps-appcenter-deploy-android/issues/19
