### PR TITLE
Move sending release note earlier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _tmp
 .vscode
 .bitrise.secrets.yml
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,97 +1,93 @@
-# steps-appcenter-deploy-android
+# AppCenter Android Deploy
 
-AppCenter Android Deploy
+[![Step changelog](https://shields.io/github/v/release/bitrise-steplib/steps-appcenter-deploy-android?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-steplib/steps-appcenter-deploy-android/releases)
 
-## How to use this Step
+Distribute your Android app through [Microsoft App Center](https://appcenter.ms/).
 
-Can be run directly with the [bitrise CLI](https://github.com/bitrise-io/bitrise),
-just `git clone` this repository, `cd` into it's folder in your Terminal/Command Line
-and call `bitrise run test`.
+<details>
+<summary>Description</summary>
 
-*Check the `bitrise.yml` file for required inputs which have to be
-added to your `.bitrise.secrets.yml` file!*
+[This Step](https://github.com/bitrise-steplib/steps-appcenter-deploy-android) integrates with the [App Center](https://appcenter.ms/)'s Distribution service and enables you to distribute your apps seamlessly to different stores, for example, App Store, MS Intune, user groups or even individual testers.
 
-Step by step:
+ ### Configuring the Step
 
-1. Open up your Terminal / Command Line
-2. `git clone` the repository
-3. `cd` into the directory of the step (the one you just `git clone`d)
-5. Create a `.bitrise.secrets.yml` file in the same directory of `bitrise.yml`
-   (the `.bitrise.secrets.yml` is a git ignored file, you can store your secrets in it)
-6. Check the `bitrise.yml` file for any secret you should set in `.bitrise.secrets.yml`
-  * Best practice is to mark these options with something like `# define these in your .bitrise.secrets.yml`, in the `app:envs` section.
-7. Once you have all the required secret parameters in your `.bitrise.secrets.yml` you can just run this step with the [bitrise CLI](https://github.com/bitrise-io/bitrise): `bitrise run test`
+ Before you start:
 
-An example `.bitrise.secrets.yml` file:
+ The Step requires an active MS App Center account.
 
-```
-envs:
-- A_SECRET_PARAM_ONE: the value for secret one
-- A_SECRET_PARAM_TWO: the value for secret two
-```
+ 1. Add the **APP path** which points to a binary file.
+ 2. Add the **mapping.txt file path**.
+ 3. Add the App Center **API token**.
+ 4. Add the **Owner name**, which means the owner of the App Center app. For an app owned by a user, the URL in App Center can look like this https://appcenter.ms/users/JoshuaWeber/apps/APIExample where the {ownername} is JoshuaWeber. For an app owned by an organization, the URL can be, for example, https://appcenter.ms/orgs/Microsoft/apps/APIExample where the {ownername} is Microsoft.
+ 5. Add the **App name** which is the name of the App Center app. For an app owned by a user, the URL in App Center might look like this: https://appcenter.ms/users/JoshuaWeber/apps/APIExample where the {app_name} is APIExample.
+ 6. Add the **Distribution groups** which means the user groups you wish to distribute the app to. Please add one group name per line.
+ 7. Add the **Distribution stores** where you wish to distribute the app to. Please add one store name per line.
+ 8. Add the **Testers** who you wish to send the app to via email. Please add one email address per line.
+ 9. Add any **Release notes for the deployed artifact**.
+ 10. Send notification emails to testers and distribution groups with the **Notify Testers** input.
+ 11. You can enforce the installation of a distribution version with the **Mandatory** input set to `yes`.
+ 12. If you set the **Debug** input to `yes`, you can enable verbose logs.
 
-## How to create your own step
+### Useful links
+- [About Android deployment with Bitrise](https://devcenter.bitrise.io/deploy/android-deploy/android-deployment-index/)
+- [About Android code signing](https://devcenter.bitrise.io/code-signing/android-code-signing/android-code-signing-index/)
 
-1. Create a new git repository for your step (**don't fork** the *step template*, create a *new* repository)
-2. Copy the [step template](https://github.com/bitrise-steplib/step-template) files into your repository
-3. Fill the `step.sh` with your functionality
-4. Wire out your inputs to `step.yml` (`inputs` section)
-5. Fill out the other parts of the `step.yml` too
-6. Provide test values for the inputs in the `bitrise.yml`
-7. Run your step with `bitrise run test` - if it works, you're ready
+### Related Steps
+- [Deploy to Huawei App Gallery](https://www.bitrise.io/integrations/steps/app-gallery-deploy)
+- [Google Play Deploy](https://www.bitrise.io/integrations/steps/google-play-deploy)
+</details>
 
-__For Step development guidelines & best practices__ check this documentation: [https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md).
+## 🧩 Get started
 
-**NOTE:**
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
 
-If you want to use your step in your project's `bitrise.yml`:
+You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
-1. git push the step into it's repository
-2. reference it in your `bitrise.yml` with the `git::PUBLIC-GIT-CLONE-URL@BRANCH` step reference style:
+## ⚙️ Configuration
 
-```
-- git::https://github.com/user/my-step.git@branch:
-   title: My step
-   inputs:
-   - my_input_1: "my value 1"
-   - my_input_2: "my value 2"
-```
+<details>
+<summary>Inputs</summary>
 
-You can find more examples of step reference styles
-in the [bitrise CLI repository](https://github.com/bitrise-io/bitrise/blob/master/_examples/tutorials/steps-and-workflows/bitrise.yml#L65).
+| Key | Description | Flags | Default |
+| --- | --- | --- | --- |
+| `app_path` | Path to binary file  For APKs, only single or universal APKs are supported: https://docs.microsoft.com/en-us/appcenter/build/react-native/android/#63-building-multiple-apks | required | `$BITRISE_APP_PATH` |
+| `mapping_path` | Path to an Android mapping.txt file. |  |  |
+| `api_token` | App Center API token | required, sensitive |  |
+| `owner_name` | Owner of the App Center app.  For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.  Here, the {owner_name} is JoshuaWeber. For an app owned by an org, the URL might be https://appcenter.ms/orgs/Microsoft/apps/APIExample and the {owner_name} would be Microsoft | required |  |
+| `app_name` | The name of the App Center app.  For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.  Here, the {app_name} is ApiExample. | required |  |
+| `distribution_group` | User groups you wish to distribute the app. One group name per line.  Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android |  |  |
+| `distribution_store` | Distribution stores you wish to distribute the app. One store name per line.  Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android |  |  |
+| `distribution_tester` | List of individual testers. One email per line.  Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android |  |  |
+| `release_notes` | Additional notes for the deployed artifact. |  | `Release notes` |
+| `notify_testers` | Send notification email to testers and distribution groups. | required | `yes` |
+| `mandatory` | Enforce installation of distribution version. Requires SDK integration. | required | `no` |
+| `debug` | Enable verbose logs | required | `no` |
+| `all_distribution_groups` | Distribute the app to all user groups on that app. Enabling this options makes it ignore distribution_group. |  | `no` |
+</details>
 
-## How to contribute to this Step
+<details>
+<summary>Outputs</summary>
 
-1. Fork this repository
-2. `git clone` it
-3. Create a branch you'll work on
-4. To use/test the step just follow the **How to use this Step** section
-5. Do the changes you want to
-6. Run/test the step before sending your contribution
-  * You can also test the step in your `bitrise` project, either on your Mac or on [bitrise.io](https://www.bitrise.io)
-  * You just have to replace the step ID in your project's `bitrise.yml` with either a relative path, or with a git URL format
-  * (relative) path format: instead of `- original-step-id:` use `- path::./relative/path/of/script/on/your/Mac:`
-  * direct git URL format: instead of `- original-step-id:` use `- git::https://github.com/user/step.git@branch:`
-  * You can find more example of alternative step referencing at: https://github.com/bitrise-io/bitrise/blob/master/_examples/tutorials/steps-and-workflows/bitrise.yml
-7. Once you're done just commit your changes & create a Pull Request
+| Environment Variable | Description |
+| --- | --- |
+| `APPCENTER_DEPLOY_STATUS` | Deployment status: 'success' or 'failed' |
+| `APPCENTER_DEPLOY_INSTALL_URL` | Install page URL of the newly deployed version. |
+| `APPCENTER_DEPLOY_DOWNLOAD_URL` | Download URL of the newly deployed version. |
+| `APPCENTER_DEPLOY_RELEASE_ID` | ID of the new release for later retrieval via App Center APIs. |
+| `APPCENTER_PUBLIC_INSTALL_PAGE_URL` | Public install page URL of the latest version. |
+| `APPCENTER_PUBLIC_INSTALL_PAGE_URLS` | When a group is public the step will AppCenter provides and the step exports a public install page URL. |
+| `APPCENTER_RELEASE_PAGE_URL` | URL to the release page containing release notes, easily share with business partners and QA for testing. |
+</details>
 
+## 🙋 Contributing
 
-## Share your own Step
+We welcome [pull requests](https://github.com/bitrise-steplib/steps-appcenter-deploy-android/pulls) and [issues](https://github.com/bitrise-steplib/steps-appcenter-deploy-android/issues) against this repository.
 
-You can share your Step or step version with the [bitrise CLI](https://github.com/bitrise-io/bitrise). If you use the `bitrise.yml` included in this repository, all you have to do is:
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
 
-1. In your Terminal / Command Line `cd` into this directory (where the `bitrise.yml` of the step is located)
-1. Run: `bitrise run test` to test the step
-1. Run: `bitrise run audit-this-step` to audit the `step.yml`
-1. Check the `share-this-step` workflow in the `bitrise.yml`, and fill out the
-   `envs` if you haven't done so already (don't forget to bump the version number if this is an update
-   of your step!)
-1. Then run: `bitrise run share-this-step` to share the step (version) you specified in the `envs`
-1. Send the Pull Request, as described in the logs of `bitrise run share-this-step`
+**Note:** this step's end-to-end tests (defined in `e2e/bitrise.yml`) are working with secrets which are intentionally not stored in this repo. External contributors won't be able to run those tests. Don't worry, if you open a PR with your contribution, we will help with running tests and make sure that they pass.
 
-That's all ;)
+Learn more about developing steps:
 
-## Trigger a new release
-
-- __merge every code changes__ to the `master` branch
-- __push the new version tag__ to the `master` branch
+- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
+- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,20 +1,22 @@
-format_version: "9"
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+app:
+  envs:
+  - ORIG_BITRISE_SOURCE_DIR: $BITRISE_SOURCE_DIR
+
 workflows:
-  vendor-update:
-    title: Vendor update
-    description: |
-      Used for updating the vendored dependencies
+  check:
     steps:
-    - script:
-        title: Vendor update
+    - git::https://github.com/bitrise-steplib/steps-check.git: { }
+
+  e2e:
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-check.git:
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            go mod vendor
-  test:
+        - workflow: e2e
+
+  sample:
     envs:
     - APK_DOWNLOAD_URL: https://raw.githubusercontent.com/bitrise-io/sample-artifacts/master/apks/app-armeabi-v7a-release.apk
     - APK_PATH: app-debug.apk
@@ -25,10 +27,6 @@ workflows:
     - APPCENTER_APP_NAME: steps-appcenter-deploy-android
     - APPCENTER_APP_OWNER: app-center-bot
     steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
     - script:
         title: Clean _tmp
         inputs:
@@ -61,89 +59,9 @@ workflows:
           - mapping_path: $MAPPING_PATH
           - distribution_tester: tooling.bot@bitrise.io
           - release_notes: Bitrise step test
-    - script:
-        title: Check output envs
+
+  generate_readme:
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main:
         inputs:
-          - content: |-
-              #!/bin/bash
-              set -ex
-
-              if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
-                exit 1
-              fi
-
-              if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
-              then
-                echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
-                exit 1
-              fi
-
-              if [ -z $APPCENTER_PUBLIC_INSTALL_PAGE_URL ]
-              then
-                echo "ERROR: APPCENTER_PUBLIC_INSTALL_PAGE_URL variable empty"
-                exit 1
-              fi
-
-              if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
-                exit 1
-              fi
-
-              if [ -z $APPCENTER_RELEASE_PAGE_URL ]
-              then
-                echo "ERROR: APPCENTER_RELEASE_PAGE_URL variable empty"
-                exit 1
-              fi
-
-              envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
-              envman add --key "APPCENTER_PUBLIC_INSTALL_PAGE_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_STATUS" --value ""
-              envman add --key "APPCENTER_RELEASE_PAGE_URL" --value ""
-
-    - path::./:
-        inputs:
-          - app_path: $AAB_PATH
-          - api_token: $API_TOKEN
-          - owner_name: $APPCENTER_APP_OWNER
-          - app_name: $APPCENTER_APP_NAME
-          - debug: "no" # Because of the upload
-          - release_notes: Bitrise step test
-    - script:
-        title: Check output envs
-        inputs:
-          - content: |-
-              #!/bin/bash
-              set -ex
-
-              if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
-                exit 1
-              fi
-
-              if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
-              then
-                echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
-                exit 1
-              fi
-
-              if [ -z $APPCENTER_DEPLOY_RELEASE_ID ];
-              then
-                echo "ERROR: APPCENTER_DEPLOY_RELEASE_ID variable empty"
-                exit 1
-              fi
-
-              if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
-                exit 1
-              fi
-
-              envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_RELEASE_ID" --value ""
-              envman add --key "APPCENTER_DEPLOY_STATUS" --value ""
+        - example_section: docs/examples.md

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -64,4 +64,4 @@ workflows:
     steps:
     - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main:
         inputs:
-        - example_section: docs/examples.md
+        - contrib_section: docs/contribution.md

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
         - api_token: $API_TOKEN
         - owner_name: $APPCENTER_APP_OWNER
         - app_name: $APPCENTER_APP_NAME
-        - debug: "no" # Because of the upload
+        - debug: "no"  # Because of the upload
         - distribution_group: |-
             Collaborators
             Public

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,35 +30,35 @@ workflows:
     - script:
         title: Clean _tmp
         inputs:
-          - content: rm -rf ./_tmp
+        - content: rm -rf ./_tmp
     - change-workdir:
         title: Change workdir to _tmp
         run_if: true
         inputs:
-          - path: ./_tmp
+        - path: ./_tmp
     - script:
         title: Download testing resources
         inputs:
-          - content: |-
-              #!/bin/bash
-              set -ex
-              curl -f $APK_DOWNLOAD_URL > $APK_PATH
-              curl -f $MAPPING_DOWNLOAD_URL > $MAPPING_PATH
-              curl -f $AAB_DOWNLOAD_URL > $AAB_PATH
+        - content: |-
+            #!/bin/bash
+            set -ex
+            curl -f $APK_DOWNLOAD_URL > $APK_PATH
+            curl -f $MAPPING_DOWNLOAD_URL > $MAPPING_PATH
+            curl -f $AAB_DOWNLOAD_URL > $AAB_PATH
     - path::./:
         inputs:
-          - app_path: $APK_PATH
-          - api_token: $API_TOKEN
-          - owner_name: $APPCENTER_APP_OWNER
-          - app_name: $APPCENTER_APP_NAME
-          - debug: "no" # Because of the upload
-          - distribution_group: |-
-              Collaborators
-              Public
-          - all_distribution_groups: "no"
-          - mapping_path: $MAPPING_PATH
-          - distribution_tester: tooling.bot@bitrise.io
-          - release_notes: Bitrise step test
+        - app_path: $APK_PATH
+        - api_token: $API_TOKEN
+        - owner_name: $APPCENTER_APP_OWNER
+        - app_name: $APPCENTER_APP_NAME
+        - debug: "no" # Because of the upload
+        - distribution_group: |-
+            Collaborators
+            Public
+        - all_distribution_groups: "no"
+        - mapping_path: $MAPPING_PATH
+        - distribution_tester: tooling.bot@bitrise.io
+        - release_notes: Bitrise step test
 
   generate_readme:
     steps:

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -1,0 +1,1 @@
+**Note:** this step's end-to-end tests (defined in `e2e/bitrise.yml`) are working with secrets which are intentionally not stored in this repo. External contributors won't be able to run those tests. Don't worry, if you open a PR with your contribution, we will help with running tests and make sure that they pass.

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -37,7 +37,7 @@ workflows:
         - api_token: $API_TOKEN
         - owner_name: $APPCENTER_APP_OWNER
         - app_name: $APPCENTER_APP_NAME
-        - debug: "no" # Because of the upload
+        - debug: "no"  # Because of the upload
         - distribution_group: |-
             Collaborators
             Public
@@ -87,7 +87,7 @@ workflows:
         - api_token: $API_TOKEN
         - owner_name: $APPCENTER_APP_OWNER
         - app_name: $APPCENTER_APP_NAME
-        - debug: "no" # Because of the upload
+        - debug: "no"  # Because of the upload
         - release_notes: Bitrise step test
     - script:
         title: Check output envs

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,0 +1,121 @@
+format_version: "11"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+workflows:
+  test_deploy_apk_and_aab:
+    envs:
+    - APK_DOWNLOAD_URL: https://raw.githubusercontent.com/bitrise-io/sample-artifacts/master/apks/app-armeabi-v7a-release.apk
+    - APK_PATH: app-debug.apk
+    - AAB_DOWNLOAD_URL: https://raw.githubusercontent.com/bitrise-io/sample-artifacts/master/app-bitrise-signed.aab
+    - AAB_PATH: app-bitrise-signed.aab
+    - MAPPING_DOWNLOAD_URL: https://raw.githubusercontent.com/bitrise-io/sample-artifacts/master/mappings/app-armeabi-v7a-release.txt
+    - MAPPING_PATH: mapping.txt
+    - APPCENTER_APP_NAME: steps-appcenter-deploy-android
+    - APPCENTER_APP_OWNER: app-center-bot
+    steps:
+    - script:
+        title: Clean _tmp
+        inputs:
+          - content: rm -rf ./_tmp
+    - change-workdir:
+        title: Change workdir to _tmp
+        run_if: true
+        inputs:
+          - path: ./_tmp
+    - script:
+        title: Download testing resources
+        inputs:
+          - content: |-
+              #!/bin/bash
+              set -ex
+              curl -f $APK_DOWNLOAD_URL > $APK_PATH
+              curl -f $MAPPING_DOWNLOAD_URL > $MAPPING_PATH
+              curl -f $AAB_DOWNLOAD_URL > $AAB_PATH
+    - path::./:
+        inputs:
+          - app_path: $APK_PATH
+          - api_token: $API_TOKEN
+          - owner_name: $APPCENTER_APP_OWNER
+          - app_name: $APPCENTER_APP_NAME
+          - debug: "no" # Because of the upload
+          - distribution_group: |-
+              Collaborators
+              Public
+          - all_distribution_groups: "no"
+          - mapping_path: $MAPPING_PATH
+          - distribution_tester: tooling.bot@bitrise.io
+          - release_notes: Bitrise step test
+    - script:
+        title: Check output envs
+        inputs:
+          - content: |-
+              #!/bin/bash
+              set -ex
+              if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
+              then
+                echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
+                exit 1
+              fi
+              if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
+              then
+                echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
+                exit 1
+              fi
+              if [ -z $APPCENTER_PUBLIC_INSTALL_PAGE_URL ]
+              then
+                echo "ERROR: APPCENTER_PUBLIC_INSTALL_PAGE_URL variable empty"
+                exit 1
+              fi
+              if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
+              then
+                echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
+                exit 1
+              fi
+              if [ -z $APPCENTER_RELEASE_PAGE_URL ]
+              then
+                echo "ERROR: APPCENTER_RELEASE_PAGE_URL variable empty"
+                exit 1
+              fi
+              envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
+              envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
+              envman add --key "APPCENTER_PUBLIC_INSTALL_PAGE_URL" --value ""
+              envman add --key "APPCENTER_DEPLOY_STATUS" --value ""
+              envman add --key "APPCENTER_RELEASE_PAGE_URL" --value ""
+    - path::./:
+        inputs:
+          - app_path: $AAB_PATH
+          - api_token: $API_TOKEN
+          - owner_name: $APPCENTER_APP_OWNER
+          - app_name: $APPCENTER_APP_NAME
+          - debug: "no" # Because of the upload
+          - release_notes: Bitrise step test
+    - script:
+        title: Check output envs
+        inputs:
+          - content: |-
+              #!/bin/bash
+              set -ex
+              if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
+              then
+                echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
+                exit 1
+              fi
+              if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
+              then
+                echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
+                exit 1
+              fi
+              if [ -z $APPCENTER_DEPLOY_RELEASE_ID ];
+              then
+                echo "ERROR: APPCENTER_DEPLOY_RELEASE_ID variable empty"
+                exit 1
+              fi
+              if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
+              then
+                echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
+                exit 1
+              fi
+              envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
+              envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
+              envman add --key "APPCENTER_DEPLOY_RELEASE_ID" --value ""
+              envman add --key "APPCENTER_DEPLOY_STATUS" --value ""

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,9 +1,14 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+app:
+  envs:
+  - APPCENTER_TOKEN: $APPCENTER_TOKEN
+
 workflows:
   test_deploy_apk_and_aab:
     envs:
+    - API_TOKEN: $APPCENTER_TOKEN
     - APK_DOWNLOAD_URL: https://raw.githubusercontent.com/bitrise-io/sample-artifacts/master/apks/app-armeabi-v7a-release.apk
     - APK_PATH: app-debug.apk
     - AAB_DOWNLOAD_URL: https://raw.githubusercontent.com/bitrise-io/sample-artifacts/master/app-bitrise-signed.aab

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -16,106 +16,106 @@ workflows:
     - script:
         title: Clean _tmp
         inputs:
-          - content: rm -rf ./_tmp
+        - content: rm -rf ./_tmp
     - change-workdir:
         title: Change workdir to _tmp
         run_if: true
         inputs:
-          - path: ./_tmp
+        - path: ./_tmp
     - script:
         title: Download testing resources
         inputs:
-          - content: |-
-              #!/bin/bash
-              set -ex
-              curl -f $APK_DOWNLOAD_URL > $APK_PATH
-              curl -f $MAPPING_DOWNLOAD_URL > $MAPPING_PATH
-              curl -f $AAB_DOWNLOAD_URL > $AAB_PATH
+        - content: |-
+            #!/bin/bash
+            set -ex
+            curl -f $APK_DOWNLOAD_URL > $APK_PATH
+            curl -f $MAPPING_DOWNLOAD_URL > $MAPPING_PATH
+            curl -f $AAB_DOWNLOAD_URL > $AAB_PATH
     - path::./:
         inputs:
-          - app_path: $APK_PATH
-          - api_token: $API_TOKEN
-          - owner_name: $APPCENTER_APP_OWNER
-          - app_name: $APPCENTER_APP_NAME
-          - debug: "no" # Because of the upload
-          - distribution_group: |-
-              Collaborators
-              Public
-          - all_distribution_groups: "no"
-          - mapping_path: $MAPPING_PATH
-          - distribution_tester: tooling.bot@bitrise.io
-          - release_notes: Bitrise step test
+        - app_path: $APK_PATH
+        - api_token: $API_TOKEN
+        - owner_name: $APPCENTER_APP_OWNER
+        - app_name: $APPCENTER_APP_NAME
+        - debug: "no" # Because of the upload
+        - distribution_group: |-
+            Collaborators
+            Public
+        - all_distribution_groups: "no"
+        - mapping_path: $MAPPING_PATH
+        - distribution_tester: tooling.bot@bitrise.io
+        - release_notes: Bitrise step test
     - script:
         title: Check output envs
         inputs:
-          - content: |-
-              #!/bin/bash
-              set -ex
-              if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
-                exit 1
-              fi
-              if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
-              then
-                echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
-                exit 1
-              fi
-              if [ -z $APPCENTER_PUBLIC_INSTALL_PAGE_URL ]
-              then
-                echo "ERROR: APPCENTER_PUBLIC_INSTALL_PAGE_URL variable empty"
-                exit 1
-              fi
-              if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
-                exit 1
-              fi
-              if [ -z $APPCENTER_RELEASE_PAGE_URL ]
-              then
-                echo "ERROR: APPCENTER_RELEASE_PAGE_URL variable empty"
-                exit 1
-              fi
-              envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
-              envman add --key "APPCENTER_PUBLIC_INSTALL_PAGE_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_STATUS" --value ""
-              envman add --key "APPCENTER_RELEASE_PAGE_URL" --value ""
+        - content: |-
+            #!/bin/bash
+            set -ex
+            if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
+            then
+              echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
+              exit 1
+            fi
+            if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
+            then
+              echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
+              exit 1
+            fi
+            if [ -z $APPCENTER_PUBLIC_INSTALL_PAGE_URL ]
+            then
+              echo "ERROR: APPCENTER_PUBLIC_INSTALL_PAGE_URL variable empty"
+              exit 1
+            fi
+            if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
+            then
+              echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
+              exit 1
+            fi
+            if [ -z $APPCENTER_RELEASE_PAGE_URL ]
+            then
+              echo "ERROR: APPCENTER_RELEASE_PAGE_URL variable empty"
+              exit 1
+            fi
+            envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
+            envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
+            envman add --key "APPCENTER_PUBLIC_INSTALL_PAGE_URL" --value ""
+            envman add --key "APPCENTER_DEPLOY_STATUS" --value ""
+            envman add --key "APPCENTER_RELEASE_PAGE_URL" --value ""
     - path::./:
         inputs:
-          - app_path: $AAB_PATH
-          - api_token: $API_TOKEN
-          - owner_name: $APPCENTER_APP_OWNER
-          - app_name: $APPCENTER_APP_NAME
-          - debug: "no" # Because of the upload
-          - release_notes: Bitrise step test
+        - app_path: $AAB_PATH
+        - api_token: $API_TOKEN
+        - owner_name: $APPCENTER_APP_OWNER
+        - app_name: $APPCENTER_APP_NAME
+        - debug: "no" # Because of the upload
+        - release_notes: Bitrise step test
     - script:
         title: Check output envs
         inputs:
-          - content: |-
-              #!/bin/bash
-              set -ex
-              if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
-                exit 1
-              fi
-              if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
-              then
-                echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
-                exit 1
-              fi
-              if [ -z $APPCENTER_DEPLOY_RELEASE_ID ];
-              then
-                echo "ERROR: APPCENTER_DEPLOY_RELEASE_ID variable empty"
-                exit 1
-              fi
-              if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
-              then
-                echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
-                exit 1
-              fi
-              envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
-              envman add --key "APPCENTER_DEPLOY_RELEASE_ID" --value ""
-              envman add --key "APPCENTER_DEPLOY_STATUS" --value ""
+        - content: |-
+            #!/bin/bash
+            set -ex
+            if [ -z $APPCENTER_DEPLOY_INSTALL_URL ]
+            then
+              echo "ERROR: APPCENTER_DEPLOY_INSTALL_URL variable empty"
+              exit 1
+            fi
+            if [ -z $APPCENTER_DEPLOY_DOWNLOAD_URL ];
+            then
+              echo "ERROR: APPCENTER_DEPLOY_DOWNLOAD_URL variable empty"
+              exit 1
+            fi
+            if [ -z $APPCENTER_DEPLOY_RELEASE_ID ];
+            then
+              echo "ERROR: APPCENTER_DEPLOY_RELEASE_ID variable empty"
+              exit 1
+            fi
+            if [ "$APPCENTER_DEPLOY_STATUS" != "success" ]
+            then
+              echo "ERROR: APPCENTER_DEPLOY_STATUS variable is $APPCENTER_DEPLOY_STATUS"
+              exit 1
+            fi
+            envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
+            envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
+            envman add --key "APPCENTER_DEPLOY_RELEASE_ID" --value ""
+            envman add --key "APPCENTER_DEPLOY_STATUS" --value ""

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 	// We think there is a limitation in the App Center API where release notes can only be modified
 	// after a release has been created (using separate endpoints). This leads to a race condition
 	// where the generated email for the release does not necessarily contain the release notes
-	// because it was added later via a separate API call. Anecdotally, this timing issue can be somewhat mitagated
+	// because it was added later via a separate API call. Anecdotally, this timing issue can be somewhat mitigated
 	// by adding the release notes as soon as possible after the release was created (i.e. calling the endpoints right after each other).
 	// In the future, we should investigate if there is a solution for updating the release notes reliably,
 	// or switch entirely to the App Center CLI which might be able to handle this correctly.

--- a/main.go
+++ b/main.go
@@ -71,6 +71,15 @@ func main() {
 
 	releaseAPI := appcenter.CreateReleaseAPI(api, release, releaseOptions)
 
+	if len(cfg.ReleaseNotes) > 0 {
+		log.Infof("Setting release notes")
+		if err := releaseAPI.SetReleaseNote(cfg.ReleaseNotes); err != nil {
+			failf("Failed to set release note, error: %s", err)
+		}
+		log.Donef("- Done")
+		fmt.Println()
+	}
+
 	log.Infof("Setting distribution group(s)")
 
 	err = releaseAPI.AddGroupsToRelease(releaseOptions.GroupNames)
@@ -82,15 +91,6 @@ func main() {
 		log.Infof("Uploading mapping file")
 		if err := releaseAPI.UploadSymbol(cfg.MappingPath); err != nil {
 			failf("Failed to upload symbol file(%s), error: %s", cfg.MappingPath, err)
-		}
-		log.Donef("- Done")
-		fmt.Println()
-	}
-
-	if len(cfg.ReleaseNotes) > 0 {
-		log.Infof("Setting release notes")
-		if err := releaseAPI.SetReleaseNote(cfg.ReleaseNotes); err != nil {
-			failf("Failed to set release note, error: %s", err)
 		}
 		log.Donef("- Done")
 		fmt.Println()

--- a/main.go
+++ b/main.go
@@ -71,6 +71,13 @@ func main() {
 
 	releaseAPI := appcenter.CreateReleaseAPI(api, release, releaseOptions)
 
+	// We think there is a limitation in the App Center API where release notes can only be modified
+	// after a release has been created (using separate endpoints). This leads to a race condition
+	// where the generated email for the release does not necessarily contain the release notes
+	// because it was added later via a separate API call. Anecdotally, this timing issues can be somewhat mitagated
+	// by adding the release notes as soon as possible after the release was created (i.e. calling the endpoints right after each other).
+	// In the future, we should investigate if there is a solution for updating the release notes reliably,
+	// or switch entirely to the App Center CLI which might be able to handle this correctly.
 	if len(cfg.ReleaseNotes) > 0 {
 		log.Infof("Setting release notes")
 		if err := releaseAPI.SetReleaseNote(cfg.ReleaseNotes); err != nil {

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 	// We think there is a limitation in the App Center API where release notes can only be modified
 	// after a release has been created (using separate endpoints). This leads to a race condition
 	// where the generated email for the release does not necessarily contain the release notes
-	// because it was added later via a separate API call. Anecdotally, this timing issues can be somewhat mitagated
+	// because it was added later via a separate API call. Anecdotally, this timing issue can be somewhat mitagated
 	// by adding the release notes as soon as possible after the release was created (i.e. calling the endpoints right after each other).
 	// In the future, we should investigate if there is a solution for updating the release notes reliably,
 	// or switch entirely to the App Center CLI which might be able to handle this correctly.

--- a/step.yml
+++ b/step.yml
@@ -53,13 +53,13 @@ toolkit:
     package_name: github.com/bitrise-steplib/steps-appcenter-deploy-android
 
 inputs:
-- app_path: "$BITRISE_APP_PATH"
+- app_path: $BITRISE_APP_PATH
   opts:
     title: APP path
     summary: Path to binary file
     description: |-
       Path to binary file
-      
+
       For APKs, only single or universal APKs are supported: https://docs.microsoft.com/en-us/appcenter/build/react-native/android/#63-building-multiple-apks
 
     is_required: true
@@ -83,7 +83,7 @@ inputs:
       Owner of the App Center app.
 
       For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.
-      
+
       Here, the {owner_name} is JoshuaWeber. For an app owned by an org, the URL might be
       https://appcenter.ms/orgs/Microsoft/apps/APIExample and the {owner_name} would be Microsoft
 
@@ -96,7 +96,7 @@ inputs:
       The name of the App Center app.
 
       For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.
-      
+
       Here, the {app_name} is ApiExample.
 
     is_required: true
@@ -124,7 +124,7 @@ inputs:
       List of individual testers. One email per line.
 
       Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
-- release_notes: "Release notes"
+- release_notes: Release notes
   opts:
     title: Release notes text
     summary: Release notes text
@@ -188,7 +188,7 @@ outputs:
 - APPCENTER_PUBLIC_INSTALL_PAGE_URLS:
   opts:
     title: Comma-separated public install pages by groups
-    summary: Comma-separated list of the public install pages URL. 
+    summary: Comma-separated list of the public install pages URL.
     description: When a group is public the step will AppCenter provides and the step exports a public install page URL.
 - APPCENTER_RELEASE_PAGE_URL:
   opts:

--- a/step.yml
+++ b/step.yml
@@ -1,4 +1,4 @@
-title: "AppCenter Android Deploy"
+title: AppCenter Android Deploy
 summary: |-
   Distribute your Android app through [Microsoft App Center](https://appcenter.ms/).
 
@@ -24,7 +24,6 @@ description: |-
    11. You can enforce the installation of a distribution version with the **Mandatory** input set to `yes`.
    12. If you set the **Debug** input to `yes`, you can enable verbose logs.
 
-
   ### Useful links
   - [About Android deployment with Bitrise](https://devcenter.bitrise.io/deploy/android-deploy/android-deployment-index/)
   - [About Android code signing](https://devcenter.bitrise.io/code-signing/android-code-signing/android-code-signing-index/)
@@ -37,14 +36,14 @@ source_code_url: https://github.com/bitrise-steplib/steps-appcenter-deploy-andro
 support_url: https://github.com/bitrise-steplib/steps-appcenter-deploy-android/issues
 
 project_type_tags:
-  - android
-  - xamarin
-  - cordova
-  - ionic
-  - react-native
-  - flutter
+- android
+- xamarin
+- cordova
+- ionic
+- react-native
+- flutter
 type_tags:
-  - deploy
+- deploy
 
 is_always_run: false
 is_skippable: false
@@ -54,145 +53,145 @@ toolkit:
     package_name: github.com/bitrise-steplib/steps-appcenter-deploy-android
 
 inputs:
-  - app_path: "$BITRISE_APP_PATH"
-    opts:
-      title: APP path
-      summary: Path to binary file
-      description: |-
-        Path to binary file
-        
-        For APKs, only single or universal APKs are supported: https://docs.microsoft.com/en-us/appcenter/build/react-native/android/#63-building-multiple-apks
+- app_path: "$BITRISE_APP_PATH"
+  opts:
+    title: APP path
+    summary: Path to binary file
+    description: |-
+      Path to binary file
+      
+      For APKs, only single or universal APKs are supported: https://docs.microsoft.com/en-us/appcenter/build/react-native/android/#63-building-multiple-apks
 
-      is_required: true
-  - mapping_path:
-    opts:
-      title: mapping.txt file path
-      summary: Path to an Android mapping.txt file.
-      description: Path to an Android mapping.txt file.
-  - api_token:
-    opts:
-      title: API Token
-      summary: App Center API token
-      description: App Center API token
-      is_required: true
-      is_sensitive: true
-  - owner_name:
-    opts:
-      title: Owner name
-      summary: Owner of the App Center app
-      description: |-
-        Owner of the App Center app.
+    is_required: true
+- mapping_path:
+  opts:
+    title: mapping.txt file path
+    summary: Path to an Android mapping.txt file.
+    description: Path to an Android mapping.txt file.
+- api_token:
+  opts:
+    title: API Token
+    summary: App Center API token
+    description: App Center API token
+    is_required: true
+    is_sensitive: true
+- owner_name:
+  opts:
+    title: Owner name
+    summary: Owner of the App Center app
+    description: |-
+      Owner of the App Center app.
 
-        For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.
-        
-        Here, the {owner_name} is JoshuaWeber. For an app owned by an org, the URL might be
-        https://appcenter.ms/orgs/Microsoft/apps/APIExample and the {owner_name} would be Microsoft
+      For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.
+      
+      Here, the {owner_name} is JoshuaWeber. For an app owned by an org, the URL might be
+      https://appcenter.ms/orgs/Microsoft/apps/APIExample and the {owner_name} would be Microsoft
 
-      is_required: true
-  - app_name:
-    opts:
-      title: App name
-      summary: The name of the App Center app
-      description: |-
-        The name of the App Center app.
+    is_required: true
+- app_name:
+  opts:
+    title: App name
+    summary: The name of the App Center app
+    description: |-
+      The name of the App Center app.
 
-        For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.
-        
-        Here, the {app_name} is ApiExample.
+      For an app owned by a user, the URL in App Center might look like https://appcenter.ms/users/JoshuaWeber/apps/APIExample.
+      
+      Here, the {app_name} is ApiExample.
 
-      is_required: true
-  - distribution_group:
-    opts:
-      title: Distribution groups
-      summary: User groups you wish to distribute the app. One group name per line.
-      description: |-
-        User groups you wish to distribute the app. One group name per line.
+    is_required: true
+- distribution_group:
+  opts:
+    title: Distribution groups
+    summary: User groups you wish to distribute the app. One group name per line.
+    description: |-
+      User groups you wish to distribute the app. One group name per line.
 
-        Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
-  - distribution_store:
-    opts:
-      title: Distribution stores
-      summary: Distribution stores you wish to distribute the app. One store name per line.
-      description: |-
-        Distribution stores you wish to distribute the app. One store name per line.
+      Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
+- distribution_store:
+  opts:
+    title: Distribution stores
+    summary: Distribution stores you wish to distribute the app. One store name per line.
+    description: |-
+      Distribution stores you wish to distribute the app. One store name per line.
 
-        Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
-  - distribution_tester:
-    opts:
-      title: Testers
-      summary: List of individual testers. One email per line.
-      description: |-
-        List of individual testers. One email per line.
+      Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
+- distribution_tester:
+  opts:
+    title: Testers
+    summary: List of individual testers. One email per line.
+    description: |-
+      List of individual testers. One email per line.
 
-        Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
-  - release_notes: "Release notes"
-    opts:
-      title: Release notes text
-      summary: Release notes text
-      description: |-
-        Additional notes for the deployed artifact.
-  - notify_testers: "yes"
-    opts:
-      title: Notify Testers
-      summary: Send notification email to testers and distribution groups.
-      description: Send notification email to testers and distribution groups.
-      value_options: ["yes", "no"]
-      is_required: true
-  - mandatory: "no"
-    opts:
-      title: Mandatory
-      summary: Enforce installation of distribution version. Requires SDK integration.
-      description: Enforce installation of distribution version. Requires SDK integration.
-      value_options: ["no", "yes"]
-      is_required: true
-  - debug: "no"
-    opts:
-      title: Debug
-      summary: Enable verbose logs
-      description: Enable verbose logs
-      value_options: ["no", "yes"]
-      is_required: true
-  - all_distribution_groups: "no"
-    opts:
-      title: All distribution groups
-      summary: Distribute the app to all user groups on that app.
-      description: |-
-        Distribute the app to all user groups on that app. Enabling this options makes it ignore distribution_group.
-      value_options: ["no", "yes"]
+      Distribution of AAB is supported only for Google Play store deployment: https://docs.microsoft.com/en-us/appcenter/distribution/uploading#android
+- release_notes: "Release notes"
+  opts:
+    title: Release notes text
+    summary: Release notes text
+    description: |-
+      Additional notes for the deployed artifact.
+- notify_testers: "yes"
+  opts:
+    title: Notify Testers
+    summary: Send notification email to testers and distribution groups.
+    description: Send notification email to testers and distribution groups.
+    value_options: ["yes", "no"]
+    is_required: true
+- mandatory: "no"
+  opts:
+    title: Mandatory
+    summary: Enforce installation of distribution version. Requires SDK integration.
+    description: Enforce installation of distribution version. Requires SDK integration.
+    value_options: ["no", "yes"]
+    is_required: true
+- debug: "no"
+  opts:
+    title: Debug
+    summary: Enable verbose logs
+    description: Enable verbose logs
+    value_options: ["no", "yes"]
+    is_required: true
+- all_distribution_groups: "no"
+  opts:
+    title: All distribution groups
+    summary: Distribute the app to all user groups on that app.
+    description: |-
+      Distribute the app to all user groups on that app. Enabling this options makes it ignore distribution_group.
+    value_options: ["no", "yes"]
 
 outputs:
-  - APPCENTER_DEPLOY_STATUS:
-    opts:
-      title: Deployment status
-      summary: "Deployment status: 'success' or 'failed'"
-      description: "Deployment status: 'success' or 'failed'"
-  - APPCENTER_DEPLOY_INSTALL_URL:
-    opts:
-      title: Install page URL
-      summary: Install page URL of the newly deployed version
-      description: Install page URL of the newly deployed version.
-  - APPCENTER_DEPLOY_DOWNLOAD_URL:
-    opts:
-      title: Download URL
-      summary: Download URL of the newly deployed version
-      description: Download URL of the newly deployed version.
-  - APPCENTER_DEPLOY_RELEASE_ID:
-    opts:
-      title: Release ID
-      summary: ID of the new release for later retrieval via App Center APIs.
-      description: ID of the new release for later retrieval via App Center APIs.
-  - APPCENTER_PUBLIC_INSTALL_PAGE_URL:
-    opts:
-      title: Public install page URL
-      summary: Public install page URL of the latest version
-      description: Public install page URL of the latest version.
-  - APPCENTER_PUBLIC_INSTALL_PAGE_URLS:
-    opts:
-      title: Comma-separated public install pages by groups
-      summary: Comma-separated list of the public install pages URL. 
-      description: When a group is public the step will AppCenter provides and the step exports a public install page URL.
-  - APPCENTER_RELEASE_PAGE_URL:
-    opts:
-      title: Release Page URL
-      summary: URL to the release page containing release notes.
-      description: URL to the release page containing release notes, easily share with business partners and QA for testing.
+- APPCENTER_DEPLOY_STATUS:
+  opts:
+    title: Deployment status
+    summary: "Deployment status: 'success' or 'failed'"
+    description: "Deployment status: 'success' or 'failed'"
+- APPCENTER_DEPLOY_INSTALL_URL:
+  opts:
+    title: Install page URL
+    summary: Install page URL of the newly deployed version
+    description: Install page URL of the newly deployed version.
+- APPCENTER_DEPLOY_DOWNLOAD_URL:
+  opts:
+    title: Download URL
+    summary: Download URL of the newly deployed version
+    description: Download URL of the newly deployed version.
+- APPCENTER_DEPLOY_RELEASE_ID:
+  opts:
+    title: Release ID
+    summary: ID of the new release for later retrieval via App Center APIs.
+    description: ID of the new release for later retrieval via App Center APIs.
+- APPCENTER_PUBLIC_INSTALL_PAGE_URL:
+  opts:
+    title: Public install page URL
+    summary: Public install page URL of the latest version
+    description: Public install page URL of the latest version.
+- APPCENTER_PUBLIC_INSTALL_PAGE_URLS:
+  opts:
+    title: Comma-separated public install pages by groups
+    summary: Comma-separated list of the public install pages URL. 
+    description: When a group is public the step will AppCenter provides and the step exports a public install page URL.
+- APPCENTER_RELEASE_PAGE_URL:
+  opts:
+    title: Release Page URL
+    summary: URL to the release page containing release notes.
+    description: URL to the release page containing release notes, easily share with business partners and QA for testing.

--- a/step.yml
+++ b/step.yml
@@ -37,7 +37,6 @@ support_url: https://github.com/bitrise-steplib/steps-appcenter-deploy-android/i
 
 project_type_tags:
 - android
-- xamarin
 - cordova
 - ionic
 - react-native

--- a/vendor/github.com/bitrise-io/appcenter/client/api.go
+++ b/vendor/github.com/bitrise-io/appcenter/client/api.go
@@ -225,7 +225,7 @@ func (api API) SetReleaseNoteOnRelease(releaseNote string, releaseID int, opts m
 		return err
 	}
 
-	statusCode, err := api.Client.jsonRequest(http.MethodPut, putURL, body, nil)
+	statusCode, err := api.Client.jsonRequest(http.MethodPatch, putURL, body, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/bitrise-io/appcenter/client/api.go
+++ b/vendor/github.com/bitrise-io/appcenter/client/api.go
@@ -225,7 +225,7 @@ func (api API) SetReleaseNoteOnRelease(releaseNote string, releaseID int, opts m
 		return err
 	}
 
-	statusCode, err := api.Client.jsonRequest(http.MethodPatch, putURL, body, nil)
+	statusCode, err := api.Client.jsonRequest(http.MethodPut, putURL, body, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context
* We think there is a limitation in the App Center API where release notes can only be modified after a release has been created (using separate endpoints).
* This leads to a **race condition** where **the generated email for the release does not necessarily contain the release notes** because it was added later via a separate API call.
* Anecdotally, this timing issue can be somewhat mitigated by **adding the release notes as soon as possible after the release was created** (i.e. calling the endpoints right after each other).
* In the future, we should investigate if there is a solution for updating the release notes reliably, or switch entirely to the App Center CLI which might be able to handle this correctly.

### Changes
* **Moved the API call that adds the release notes closer in execution to the API call that creates the release.**
* Finished migration to Unified CI.
* Fixed YAML formatting.
* Fixed E2E test.
* Re-generated README.